### PR TITLE
Added empty default option for appname

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -44,6 +44,12 @@ class NewrelicPackage extends Package {
     }
 
     public function on_start() {
+
+        if (!extension_loaded('newrelic')) {
+            // don't try to call newrelic functions if extension is not loaded
+            return;
+        }
+
         $r = Request::get();
 
         // make sure newrelic knows on which line we are

--- a/controller.php
+++ b/controller.php
@@ -38,7 +38,7 @@ class NewrelicPackage extends Package {
         $this->addSinglePage('/dashboard/system/optimization/newrelic', t('New Relic'), t('New Relic perfomance monitoring.'));
 
         // add default configuration values
-        $this->package->saveConfig('NEWRELIC_APPNAME', 'HOSTNAME');
+        $this->package->saveConfig('NEWRELIC_APPNAME', 'NONE');
         $this->package->saveConfig('NEWRELIC_BACKGROUND_JOBS', '\/tools\/required\/jobs');
         $this->package->saveConfig('NEWRELIC_IGNORE_TRANSACTIONS', '^\/dashboard\/');
     }
@@ -65,8 +65,11 @@ class NewrelicPackage extends Package {
             case 'SITENAME':
                 newrelic_set_appname(SITE);
                 break;
-            default:
+            case 'CUSTOM':
                 newrelic_set_appname($pkg->config('NEWRELIC_APPNAME_VALUE'));
+                break;
+            default:
+                // NONE
                 break;
         }
 

--- a/controller.php
+++ b/controller.php
@@ -10,11 +10,11 @@ class NewrelicPackage extends Package {
     private $package;
 
     public function getPackageName() {
-        return t("Newrelic");
+        return t("New Relic");
     }
 
     public function getPackageDescription() {
-        return t("Installs the Newrelic integration add-on.");
+        return t("Installs the New Relic integration add-on.");
     }
 
     private function addSinglePage($path, $name, $description = '', $icon = '') {
@@ -35,7 +35,7 @@ class NewrelicPackage extends Package {
         $this->package = parent::install();
 
         // install dashboard pages
-        $this->addSinglePage('/dashboard/system/optimization/newrelic', t('Newrelic'), t('Newrelic perfomance monitoring.'));
+        $this->addSinglePage('/dashboard/system/optimization/newrelic', t('New Relic'), t('New Relic perfomance monitoring.'));
 
         // add default configuration values
         $this->package->saveConfig('NEWRELIC_APPNAME', 'HOSTNAME');

--- a/single_pages/dashboard/system/optimization/newrelic.php
+++ b/single_pages/dashboard/system/optimization/newrelic.php
@@ -6,13 +6,13 @@ $ih = Loader::helper('concrete/interface');
 $dh = Loader::helper('concrete/dashboard');
 ?>
 
-<?php echo $dh->getDashboardPaneHeaderWrapper(t('Newrelic Settings'), t('Specify your custom Newrelic settings in this screen.'), 'span5 offset3', false); ?>
+<?php echo $dh->getDashboardPaneHeaderWrapper(t('New Relic Settings'), t('Specify your custom New Relic settings in this screen.'), 'span5 offset3', false); ?>
 
 <form method="post" id="form_newrelic_settings" action="<?php echo $this->action('save') ?>">
     <?php echo $vt->output(); ?>
 
     <div class="ccm-pane-body">
-        <h5><?php echo t('Appname used in Newrelic') ?></h5>
+        <h5><?php echo t('Appname used in New Relic') ?></h5>
         <div class="clearfix inputs-list">
             <label for="appName">
                 <input type="radio" name="appName" <?php echo $appName === 'SITENAME' ? 'checked="checked"' : '' ?> value="SITENAME"/> <?php echo t('Sitename (%s)', SITE) ?>

--- a/single_pages/dashboard/system/optimization/newrelic.php
+++ b/single_pages/dashboard/system/optimization/newrelic.php
@@ -15,6 +15,10 @@ $dh = Loader::helper('concrete/dashboard');
         <h5><?php echo t('Appname used in New Relic') ?></h5>
         <div class="clearfix inputs-list">
             <label for="appName">
+                <input type="radio" name="appName" <?php echo $appName === 'NONE' ? 'checked="checked"' : '' ?> value="NONE"/> <?php echo t('Default (don\'t override appname)') ?>
+            </label>
+
+            <label for="appName">
                 <input type="radio" name="appName" <?php echo $appName === 'SITENAME' ? 'checked="checked"' : '' ?> value="SITENAME"/> <?php echo t('Sitename (%s)', SITE) ?>
             </label>
 


### PR DESCRIPTION
> Usually, when you change an
> application name, the agent simply discards the current transaction and does not
> send any of the accumulated metrics to the daemon.
> https://docs.newrelic.com/docs/php/the-php-api

See related discussion in https://github.com/ekino/EkinoNewRelicBundle/issues/24. Adding the xmit parameter as another configuration setting would an idea.

Also some smaller improvements.
